### PR TITLE
Снятие вайтлиста с части ролей

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -779,8 +779,6 @@
     makeSentient: true
     allowSpeech: true
     allowMovement: true
-    requirements:
-    - !type:WhitelistRequirement
     name: ghost-role-information-punpun-name
     description: ghost-role-information-punpun-description
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -3,8 +3,6 @@
   name: job-name-prisoner
   description: job-description-prisoner
   playTimeTracker: JobPrisoner
-  requirements:
-    - !type:WhitelistRequirement
   startingGear: PrisonerGear
   alwaysUseSpawner: true
   canBeAntag: false

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -198,8 +198,6 @@
     allowMovement: true
     allowSpeech: true
     makeSentient: true
-    requirements:
-    - !type:WhitelistRequirement
     name: ghost-role-information-artifact-name
     description: ghost-role-information-artifact-description
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
@@ -7,8 +7,6 @@
   - type: GhostRole
     name: ghost-role-information-clippy-name
     description: ghost-role-information-clippy-description
-    requirements:
-    - !type:WhitelistRequirement
   - type: Loadout
     prototypes: [ MobClippyGear ]
   - type: RandomMetadata
@@ -45,8 +43,6 @@
   - type: GhostRole
     name: ghost-role-information-clarpy-name
     description: ghost-role-information-clarpy-description
-    requirements:
-    - !type:WhitelistRequirement
   - type: Loadout
     prototypes: [ MobClarpyGear ]
   - type: ReplacementAccent


### PR DESCRIPTION
Убрана необходимость вайт-листа со следующих ролей:
1. Разумный артефакт
2. Пун Пун
3. Питомцы
4. Заключенный - гост роль шаттла ДСБФ, многие просили убрать с него ВЛ.